### PR TITLE
Explore coveralls in R

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,8 +63,5 @@ jobs:
         if: matrix.config.coveralls == 'true'
         continue-on-error: true
         run: |
-          covr::coveralls(
-            function_exclusions = c("\\.onLoad", "showcase"),
-            repo_token = "${{ secrets.COVERALLS_TOKEN }}",
-            service_name='drone')
+          covr::coveralls()
         shell: Rscript {0}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# documentation at https://docs.travis-ci.com/user/languages/r
+
+# this ci is used to update test coverage for coveralls
+language: r
+
+sudo: true
+cache: packages
+warnings_are_errors: true
+
+after_success:
+  - Rscript -e 'covr::coveralls(function_exclusions = c("\\.onLoad", "showcase"))'


### PR DESCRIPTION
There is no a good example how to implement coveralls in ci for r packages. I don't think coveralls has been used for 
R project across Sage yet. I would like to explore a bit more.

Initially, I just put covr function in the ci. It could auto update coverage in coveralls, but the branch is not tracked and the badge will not be updated:
```r
- name: Test coverage
  if: matrix.config.coveralls == 'true'
  continue-on-error: true
  run: |
    covr::coveralls(
            function_exclusions = c("\\.onLoad", "showcase"),
            repo_token = "${{ secrets.COVERALLS_TOKEN }}",
            service_name='drone')
  shell: Rscript {0}
```

1. I am trying to use travis-ci - if `service_name` set NULL, it will use travis-ci
2. If not working, I will use covcode instead.