### PR TITLE
Save `theme_config.rds` into right working dir in app

### DIFF
--- a/R/mod_palette_panel.R
+++ b/R/mod_palette_panel.R
@@ -109,14 +109,8 @@ palettePanel <- function(id, head.id, parent.session) {
       })
 
       observeEvent(input$`save-btn`, {
-        vars()
-        path <- "./theme_config.rds"
-        isolate({
-          saveRDS(vars(), path)
-          output[["save-progress"]] <- renderText(
-            sprintf("'%s' is updated!", path)
-          )
-        })
+        saveRDS(vars(), "theme_config.rds")
+        output[["save-progress"]] <- renderText("'theme_config.rds' is updated!")
       })
     }
   )

--- a/R/showcase.R
+++ b/R/showcase.R
@@ -9,5 +9,6 @@
 #' @rdname showcase
 #' @export
 showcase <- function() {
+  Sys.setenv(WORKING_DIR = getwd())
   shiny::shinyAppFile(system.file("examples/app.R", package = "dcamodules", mustWork = TRUE))
 }

--- a/inst/examples/app.R
+++ b/inst/examples/app.R
@@ -170,6 +170,11 @@ ui <- dashboardPage(
 
 server <- function(input, output, session) {
   palettePanel("palette-panel", "theme", session)
+
+  # set the app's working dir
+  # so the theme_config.rds can be saved to user's working dir
+  setwd(Sys.getenv("WORKING_DIR"))
+
   observeEvent(input$btn_theme, {
     output$theme <- renderUI({
       use_dca(theme = input$btn_theme)


### PR DESCRIPTION
- fixes #19 

Now the `theme_config.rds` should be saved into where user runs the `showcase()`.
<img width="216" alt="Screen Shot 2023-01-11 at 2 04 08 PM" src="https://user-images.githubusercontent.com/73901500/211896311-439d5671-ed38-41e9-94d0-64ba301bac5e.png">
